### PR TITLE
Adds new commands and pickers

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ A Neovim plugin for seamless integration with [Aider](https://github.com/paul-ga
   - Use fzf-lua or Telescope for file selection (multi-select supported), with multiple file viewer options 🔭
     - For Telescope, the custom file-loading action is available in `git_files`, `find_files`, `buffers`, and `oldfiles` 📄
     - For fzf-lua, any file finder following standard file parameter conventions is supported 🔍
-  - Outside of watch mode, use `AiderLoad` without arguments to add the current file (`/add`), or specify file arguments ➕
+  - Outside of watch mode, use `AiderAdd` without arguments to add the current file (`/add`), or specify file arguments ➕
 - Ask questions about your code, with support for visual selections ❓
   - `AiderAsk` with a visual selection will prompt you for input and add the selected code to the prompt 🙋
 - For diff viewing, accepting or rejecting changes: 🔍
@@ -103,7 +103,7 @@ return {
       },
       {
         "<leader>al",
-        "<cmd>AiderLoad<CR>",
+        "<cmd>AiderAdd<CR>",
         desc = "Add file to aider",
       },
       {
@@ -202,7 +202,7 @@ require('packer').startup(function(use)
       vim.keymap.set('n', '<leader>a<space>', '<cmd>AiderToggle<CR>', vim.tbl_extend('force', opts, { desc = 'Toggle Aider' }))
       vim.keymap.set('n', '<leader>af', '<cmd>AiderToggle float<CR>', vim.tbl_extend('force', opts, { desc = 'Toggle Aider Float' }))
       vim.keymap.set('n', '<leader>av', '<cmd>AiderToggle vertical<CR>', vim.tbl_extend('force', opts, { desc = 'Toggle Aider Vertical' }))
-      vim.keymap.set('n', '<leader>al', '<cmd>AiderLoad<CR>', vim.tbl_extend('force', opts, { desc = 'Add file to aider' }))
+      vim.keymap.set('n', '<leader>al', '<cmd>AiderAdd<CR>', vim.tbl_extend('force', opts, { desc = 'Add file to aider' }))
       vim.keymap.set({ 'v', 'n' }, '<leader>ad', '<cmd>AiderAsk<CR>', vim.tbl_extend('force', opts, { desc = 'Ask with selection' }))
       vim.keymap.set('n', '<leader>am', '<cmd>Telescope model_picker<CR>', vim.tbl_extend('force', opts, { desc = 'Change model' }))
       vim.keymap.set('n', '<leader>ams', '<cmd>AiderSend /model sonnet<CR>', vim.tbl_extend('force', opts, { desc = 'Switch to sonnet' }))
@@ -245,7 +245,7 @@ vim.keymap.set('n', '<leader>as', '<cmd>AiderSpawn<CR>', { noremap = true, silen
 vim.keymap.set('n', '<leader>a<space>', '<cmd>AiderToggle<CR>', { noremap = true, silent = true, desc = 'Toggle Aider' })
 vim.keymap.set('n', '<leader>af', '<cmd>AiderToggle float<CR>', { noremap = true, silent = true, desc = 'Toggle Aider Float' })
 vim.keymap.set('n', '<leader>av', '<cmd>AiderToggle vertical<CR>', { noremap = true, silent = true, desc = 'Toggle Aider Vertical' })
-vim.keymap.set('n', '<leader>al', '<cmd>AiderLoad<CR>', { noremap = true, silent = true, desc = 'Add file to aider' })
+vim.keymap.set('n', '<leader>al', '<cmd>AiderAdd<CR>', { noremap = true, silent = true, desc = 'Add file to aider' })
 vim.keymap.set({ 'v', 'n' }, '<leader>ad', '<cmd>AiderAsk<CR>', { noremap = true, silent = true, desc = 'Ask with selection' })
 vim.keymap.set('n', '<leader>am', '<cmd>Telescope model_picker<CR>', { noremap = true, silent = true, desc = 'Change model' })
 vim.keymap.set('n', '<leader>ams', '<cmd>AiderSend /model sonnet<CR>', { noremap = true, silent = true, desc = 'Switch to sonnet' })
@@ -270,7 +270,8 @@ call plug#end()
   - `float` - Switch to floating window (default) 🪟
   - `tab` - Switch to new tab 📑
   - Without a direction argument, it opens in the last specified direction (or the toggleterm specified default). With a direction argument, it will switch the terminal to that layout (even if already open).
-- `:AiderLoad [files...]` - Load files into the Aider session. If no files are specified, the current file is loaded 📂
+- `:AiderAdd [files...]` - Add files to the Aider session. If no files are specified, the current file is added 📂
+  - `:AiderLoad` is deprecated and will be removed in a future version - use `:AiderAdd` instead
 - `:AiderAsk [prompt]` - Ask a question using the `/ask` command. Without a prompt, an input popup will appear. In visual mode, the selected text is added to the prompt 🙋
 - `:AiderSend [command]` - Send a command to Aider. In visual mode, the selected text is added to the command 📨
 
@@ -289,6 +290,7 @@ Usage:
 - Multiple files: Use `Shift-Tab` to select multiple files, then press `Ctrl-l` to load all selected files ➕
 - The files will be automatically added to your current Aider session if one exists, or start a new session if none is active 🧑‍💻
   - If `watch_mode` is set (as per the default), the file will be added in the background, otherwise Aider will be brought to the foreground 📂
+  - Note: `AiderLoad` is deprecated - use `AiderAdd` instead
 - fzf-lua also supports a select-all behavior, useful for loading all files matching a specific suffix, for example 💯
 
 ## 🔭 Telescope Integration

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ A Neovim plugin for seamless integration with [Aider](https://github.com/paul-ga
   - Use fzf-lua or Telescope for file selection (multi-select supported), with multiple file viewer options 🔭
     - For Telescope, the custom file-loading action is available in `git_files`, `find_files`, `buffers`, and `oldfiles` 📄
     - For fzf-lua, any file finder following standard file parameter conventions is supported 🔍
-  - Outside of watch mode, use `AiderAdd` without arguments to add the current file (`/add`), or specify file arguments ➕
+  - Use `AiderAdd` without arguments to add the current file (`/add`), or specify file arguments ➕
 - Ask questions about your code, with support for visual selections ❓
   - `AiderAsk` with a visual selection will prompt you for input and add the selected code to the prompt 🙋
 - For diff viewing, accepting or rejecting changes: 🔍
@@ -286,6 +286,7 @@ Integrating with fzf-lua allows for quick and efficient loading of files into Ai
 - **Git Status**: Modified/untracked files (`:FzfLua git_status`)
 
 Usage:
+
 - Single file: Navigate to a file and press `Ctrl-l` to load it into Aider 📄
 - Multiple files: Use `Shift-Tab` to select multiple files, then press `Ctrl-l` to load all selected files ➕
 - The files will be automatically added to your current Aider session if one exists, or start a new session if none is active 🧑‍💻

--- a/README.md
+++ b/README.md
@@ -287,10 +287,9 @@ Integrating with fzf-lua allows for quick and efficient loading of files into Ai
 - **Git Status**: Modified/untracked files (`:FzfLua git_status`)
 
 Usage:
-- Single file: Navigate to a file and press `Ctrl-l` to load it into Aider 📄
-- Single file (read-only): Navigate to a file and press `Ctrl-r` to load it in read-only mode 📄
-- Remove file: Navigate to a file and press `Ctrl-z` to remove it from Aider 🗑️
-- Multiple files: Use `Shift-Tab` to select multiple files, then press `Ctrl-l` to load all selected files ➕
+- Load files: Navigate to files and press `Ctrl-l` to load them into Aider (supports multi-select) 📄
+- Load read-only: Press `Ctrl-r` to load files in read-only mode (supports multi-select) 📄
+- Remove files: Press `Ctrl-z` to remove files from Aider (supports multi-select) 🗑️
 - The files will be automatically added to your current Aider session if one exists, or start a new session if none is active 🧑‍💻
   - Use `Ctrl-r` to add files in read-only mode and `Ctrl-z` to remove files from the session
   - If `watch_mode` is set (as per the default), the file will be added in the background, otherwise Aider will be brought to the foreground 📂
@@ -302,11 +301,9 @@ Usage:
 Telescope integration enables seamless file loading into Aider from various Telescope pickers. When Telescope is installed, you can use `<C-l>` load files into Aider:
 
 - Current pickers with this registered action include: find_files, git_files, buffers and oldfiles 🔭
-- Single file: Navigate to a file and press `<C-l>` to load it into Aider. 📄
-- Single file (read-only): Navigate to a file and press `<C-r>` to load it in read-only mode. 📄
-- Remove file: Navigate to a file and press `<C-z>` to remove it from Aider. 🗑️
-- Multiple files: Use multi-select to choose files (default <tab>), then press `<C-l>` to load all selected files. ➕
-- Multiple files: Use multi-select to choose files, then press `<C-r>` to load all selected files in read-only mode. ➕
+- Load files: Navigate to files and press `<C-l>` to load them into Aider (supports multi-select) 📄
+- Load read-only: Press `<C-r>` to load files in read-only mode (supports multi-select) 📄
+- Remove files: Press `<C-z>` to remove files from Aider (supports multi-select) 🗑️
 - The files will be automatically added to your current Aider session if one exists, or start a new session if none is active. 🧑‍💻
   - If `watch_mode` is set (as per the default), the file will be added in the background, otherwise Aider will be brought to the foreground 📂
 

--- a/README.md
+++ b/README.md
@@ -287,10 +287,12 @@ Integrating with fzf-lua allows for quick and efficient loading of files into Ai
 - **Git Status**: Modified/untracked files (`:FzfLua git_status`)
 
 Usage:
-
 - Single file: Navigate to a file and press `Ctrl-l` to load it into Aider 📄
+- Single file (read-only): Navigate to a file and press `Ctrl-r` to load it in read-only mode 📄
+- Remove file: Navigate to a file and press `Ctrl-z` to remove it from Aider 🗑️
 - Multiple files: Use `Shift-Tab` to select multiple files, then press `Ctrl-l` to load all selected files ➕
 - The files will be automatically added to your current Aider session if one exists, or start a new session if none is active 🧑‍💻
+  - Use `Ctrl-r` to add files in read-only mode and `Ctrl-z` to remove files from the session
   - If `watch_mode` is set (as per the default), the file will be added in the background, otherwise Aider will be brought to the foreground 📂
   - Note: `AiderLoad` is deprecated - use `AiderAdd` instead
 - fzf-lua also supports a select-all behavior, useful for loading all files matching a specific suffix, for example 💯
@@ -301,7 +303,10 @@ Telescope integration enables seamless file loading into Aider from various Tele
 
 - Current pickers with this registered action include: find_files, git_files, buffers and oldfiles 🔭
 - Single file: Navigate to a file and press `<C-l>` to load it into Aider. 📄
+- Single file (read-only): Navigate to a file and press `<C-r>` to load it in read-only mode. 📄
+- Remove file: Navigate to a file and press `<C-z>` to remove it from Aider. 🗑️
 - Multiple files: Use multi-select to choose files (default <tab>), then press `<C-l>` to load all selected files. ➕
+- Multiple files: Use multi-select to choose files, then press `<C-r>` to load all selected files in read-only mode. ➕
 - The files will be automatically added to your current Aider session if one exists, or start a new session if none is active. 🧑‍💻
   - If `watch_mode` is set (as per the default), the file will be added in the background, otherwise Aider will be brought to the foreground 📂
 
@@ -323,12 +328,6 @@ require('aider').setup({
 
   -- function to run when aider updates file/s, useful for triggering git diffs
   after_update_hook = nil,
-
-  -- The keybinding for adding files to Aider from fzf-lua file pickers
-  fzf_action_key = "ctrl-l",
-
-  -- The keybinding for adding files to Aider from Telescope file pickers
-  telescope_action_key = "<C-l>",
 
   -- Filters for the `Telescope model_picker`
   model_picker_search = { "^anthropic/", "^openai/", "^gemini/" },
@@ -399,6 +398,25 @@ require('aider').setup({
       height = function()
         return math.floor(vim.api.nvim_win_get_height(0) * 0.95)
       end,
+    },
+  },
+  -- Telescope key mappings
+  telescope = {
+    -- Runs `/add <files>` for selected entries (with multi-select supported)
+    add = "<C-l>",
+    -- Runs `/read-only <files>` for selected entries (with multi-select supported)
+    read_only = "<C-r>",
+    -- Runs `/drop <files>` for selected entries (with multi-select supported)
+    drop = "<C-z>",
+  },
+  -- fzf-lua key mappings
+  fzf = {
+    -- Runs `/add <files>` for selected entries (with multi-select supported)
+    add = "ctrl-l",
+    -- Runs `/read-only <files>` for selected entries (with multi-select supported)
+    read_only = "ctrl-r",
+    -- Runs `/drop <files>` for selected entries (with multi-select supported)
+    drop = "ctrl-z",
     },
   },
   -- theme colors for aider

--- a/README.md
+++ b/README.md
@@ -267,8 +267,8 @@ call plug#end()
 - `:AiderToggle [direction]` - Toggle the Aider terminal window. Optional direction can be: 🧑‍💻
   - `vertical` - Switch to vertical split ↔️
   - `horizontal` - Switch to horizontal split ↕️
-  - `float` - Switch to floating window (default) 🪟
-  - `tab` - Switch to new tab 📑
+  - `float` - Switch to floating window 🪟
+  - `tab` - Switch to new tab 📑 (best for fullscreen toggle)
   - Without a direction argument, it opens in the last specified direction (or the toggleterm specified default). With a direction argument, it will switch the terminal to that layout (even if already open).
 - `:AiderAdd [files...]` - Add files to the Aider session. If no files are specified, the current file is added 📂
   - `:AiderLoad` is deprecated and will be removed in a future version - use `:AiderAdd` instead
@@ -278,7 +278,7 @@ call plug#end()
 
 ## 🤝 FZF-lua Integration
 
-Integrating with fzf-lua allows for quick and efficient loading of files into Aider directly from the fzf-lua file picker. When fzf-lua is installed, you can use `Ctrl-l` in the following fzf-lua pickers to load files into Aider:
+Integrating with fzf-lua allows for quick and efficient loading of files into Aider directly from the fzf-lua file pickers. When fzf-lua is installed, you can use mappings in the following native pickers:
 
 - **Files**: Regular file picker (`:FzfLua files`)
 - **Git Files**: Files tracked by Git (`:FzfLua git_files`)
@@ -287,14 +287,13 @@ Integrating with fzf-lua allows for quick and efficient loading of files into Ai
 - **Git Status**: Modified/untracked files (`:FzfLua git_status`)
 
 Usage:
+
 - Load files: Navigate to files and press `Ctrl-l` to load them into Aider (supports multi-select) 📄
 - Load read-only: Press `Ctrl-r` to load files in read-only mode (supports multi-select) 📄
 - Remove files: Press `Ctrl-z` to remove files from Aider (supports multi-select) 🗑️
 - The files will be automatically added to your current Aider session if one exists, or start a new session if none is active 🧑‍💻
-  - Use `Ctrl-r` to add files in read-only mode and `Ctrl-z` to remove files from the session
   - If `watch_mode` is set (as per the default), the file will be added in the background, otherwise Aider will be brought to the foreground 📂
   - Note: `AiderLoad` is deprecated - use `AiderAdd` instead
-- fzf-lua also supports a select-all behavior, useful for loading all files matching a specific suffix, for example 💯
 
 ## 🔭 Telescope Integration
 
@@ -327,7 +326,7 @@ require('aider').setup({
   after_update_hook = nil,
 
   -- Filters for the `Telescope model_picker`
-  model_picker_search = { "^anthropic/", "^openai/", "^gemini/" },
+  model_picker_search = { "^anthropic/", "^openai/", "^gemini/" "^deepseek/" },
 
   -- Enable the `--watch-files` flag for Aider, enabling automatic startup on valid comment creation
   watch_files = true,
@@ -431,11 +430,11 @@ require('aider').setup({
 
 ### Recommended Git Practices 🧑‍🏫
 
-To get the most out of `aider.nvim`, it's essential to use Git effectively. Git is the primary tool for managing and viewing changes made by Aider. Fortunately, Neovim offers excellent tools for Git integration, including `diffview`, `gitsigns`, and `telescope`. Familiarizing yourself with these tools and using them alongside `aider.nvim` will significantly enhance your Aider experience.
+To get the most out of `aider.nvim`, it's essential to use Git effectively. Git is the primary tool for managing and viewing changes made by Aider. Fortunately, Neovim offers excellent tools for Git integration, including `diffview`, `gitsigns`, and `telescope` (or fzf-lua). Familiarizing yourself with these tools and using them alongside `aider.nvim` will significantly enhance your Neovim Aider experience.
 
 ### Simplified Git Workflow (`--no-auto-commits`) 😌
 
-For users less familiar with advanced Git commands like `git reset`, a simplified workflow is available using the `--no-auto-commits` option. You can set this option via `aider_args` in your `aider.nvim` configuration or in the `~/.aider.conf.yml` file. This approach simplifies the Git actions needed to manage Aider's changes.
+For users less familiar with Git commands like `git reset`, a simplified workflow is available using the `--no-auto-commits` option. You can set this option via `aider_args` or in the `~/.aider.conf.yml` file. This approach simplifies the Git actions needed to manage Aider's changes, however, it reduces your ability to view prior changes that were overridden.
 
 #### Visualizing Changes Without Auto-commits 🔍
 
@@ -451,9 +450,14 @@ end
 after_update_hook = function()
   vim.cmd("Telescope git_status")
 end
+
+-- Using fzf-lua to show the diffs:
+after_update_hook = function()
+  vim.cmd("FzfLua git_status")
+end
 ```
 
-These hooks display diffs of Aider's changes alongside other uncommitted modifications in your working directory. After reviewing, commit all changes to accept them, or use `gitsigns` for selective staging, unstaging, or reverting of hunks or files.
+These hooks display diffs of Aider's changes alongside other uncommitted modifications in your working directory. After reviewing, commit all changes to accept them, or use `gitsigns` for selective staging, unstaging, or reverting individual hunks or files.
 
 #### Useful `gitsigns` Mappings 🧑‍💻
 

--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ call plug#end()
   - Without a direction argument, it opens in the last specified direction (or the toggleterm specified default). With a direction argument, it will switch the terminal to that layout (even if already open).
 - `:AiderAdd [files...]` - Add files to the Aider session. If no files are specified, the current file is added 📂
   - `:AiderLoad` is deprecated and will be removed in a future version - use `:AiderAdd` instead
+- `:AiderReadOnly [files...]` - Add files to the Aider session in read-only mode. If no files are specified, the current file is added 📂
 - `:AiderAsk [prompt]` - Ask a question using the `/ask` command. Without a prompt, an input popup will appear. In visual mode, the selected text is added to the prompt 🙋
 - `:AiderSend [command]` - Send a command to Aider. In visual mode, the selected text is added to the command 📨
 

--- a/lua/aider/commands.lua
+++ b/lua/aider/commands.lua
@@ -146,6 +146,18 @@ function M.setup(opts)
 		complete = "file",
 	})
 
+	vim.api.nvim_create_user_command("AiderDrop", function(opt)
+		local files = opt.fargs
+		if #files == 0 then
+			files = { vim.api.nvim_buf_get_name(0) }
+		end
+		terminal.drop(files)
+	end, {
+		nargs = "*",
+		desc = "Load files into Aider",
+		complete = "file",
+	})
+
 	vim.api.nvim_create_user_command("AiderSend", handle_aider_send, {
 		nargs = "*",
 		range = true, -- This enables the command to work with selections

--- a/lua/aider/commands.lua
+++ b/lua/aider/commands.lua
@@ -111,6 +111,7 @@ function M.setup(opts)
 	})
 
 	vim.api.nvim_create_user_command("AiderLoad", function(opt)
+		vim.notify("Deprecated: AiderLoad is deprecated. Use AiderAdd instead.", vim.log.levels.WARN)
 		local files = opt.fargs
 		if #files == 0 then
 			files = { vim.api.nvim_buf_get_name(0) }

--- a/lua/aider/commands.lua
+++ b/lua/aider/commands.lua
@@ -115,7 +115,31 @@ function M.setup(opts)
 		if #files == 0 then
 			files = { vim.api.nvim_buf_get_name(0) }
 		end
-		terminal.load_files(files)
+		terminal.add(files)
+	end, {
+		nargs = "*",
+		desc = "Load files into Aider",
+		complete = "file",
+	})
+
+	vim.api.nvim_create_user_command("AiderAdd", function(opt)
+		local files = opt.fargs
+		if #files == 0 then
+			files = { vim.api.nvim_buf_get_name(0) }
+		end
+		terminal.add(files)
+	end, {
+		nargs = "*",
+		desc = "Load files into Aider",
+		complete = "file",
+	})
+
+	vim.api.nvim_create_user_command("AiderReadOnly", function(opt)
+		local files = opt.fargs
+		if #files == 0 then
+			files = { vim.api.nvim_buf_get_name(0) }
+		end
+		terminal.read_only(files)
 	end, {
 		nargs = "*",
 		desc = "Load files into Aider",

--- a/lua/aider/fzf.lua
+++ b/lua/aider/fzf.lua
@@ -2,7 +2,7 @@ local M = {}
 
 ---@param selected table List of selected files
 ---@param fopts table Fzf options
-local function get_paths(selected, opts)
+local function get_paths(selected, fopts)
 	local cleaned_paths = {}
 	for _, entry in ipairs(selected) do
 		local file_info = require("fzf-lua.path").entry_to_file(entry, fopts)
@@ -27,6 +27,11 @@ function M.read_only(selected, fopts)
 	require("aider.terminal").read_only(cleaned_paths)
 end
 
+function M.drop(selected, fopts)
+	local cleaned_paths = get_paths(selected, fopts)
+	require("aider.terminal").drop(cleaned_paths)
+end
+
 ---Setup fzf-lua integration
 ---@param config AiderConfig Configuration options
 function M.setup(config)
@@ -46,6 +51,9 @@ function M.setup(config)
 
 		section.actions = section.actions or {}
 		section.actions[config.fzf.read_only] = M.read_only
+
+		section.actions = section.actions or {}
+		section.actions[config.fzf.drop] = M.drop
 	end
 
 	-- Setup actions for different fzf sections

--- a/lua/aider/fzf.lua
+++ b/lua/aider/fzf.lua
@@ -9,7 +9,7 @@ function M.add(selected, fopts)
 		local file_info = require("fzf-lua.path").entry_to_file(entry, fopts)
 		table.insert(cleaned_paths, file_info.path)
 	end
-	require("aider.terminal").load_files(cleaned_paths)
+	require("aider.terminal").add(cleaned_paths)
 end
 
 ---Setup fzf-lua integration

--- a/lua/aider/fzf.lua
+++ b/lua/aider/fzf.lua
@@ -1,15 +1,30 @@
 local M = {}
 
----Load selected files into aider
 ---@param selected table List of selected files
 ---@param fopts table Fzf options
-function M.add(selected, fopts)
+local function get_paths(selected, opts)
 	local cleaned_paths = {}
 	for _, entry in ipairs(selected) do
 		local file_info = require("fzf-lua.path").entry_to_file(entry, fopts)
 		table.insert(cleaned_paths, file_info.path)
 	end
+	return cleaned_paths
+end
+
+---Load selected files into aider
+---@param selected table List of selected files
+---@param fopts table Fzf options
+function M.add(selected, fopts)
+	local cleaned_paths = get_paths(selected, fopts)
 	require("aider.terminal").add(cleaned_paths)
+end
+
+---Load selected files into aider
+---@param selected table List of selected files
+---@param fopts table Fzf options
+function M.read_only(selected, fopts)
+	local cleaned_paths = get_paths(selected, fopts)
+	require("aider.terminal").read_only(cleaned_paths)
 end
 
 ---Setup fzf-lua integration
@@ -22,8 +37,15 @@ function M.setup(config)
 
 	-- Helper to add action to fzf section
 	local function add_action_to_section(section)
+		if config.fzf_action_key then
+			config.fzf.add = config.fzf_action_key
+		end
+
 		section.actions = section.actions or {}
-		section.actions[config.fzf_action_key] = M.add
+		section.actions[config.fzf.add] = M.add
+
+		section.actions = section.actions or {}
+		section.actions[config.fzf.read_only] = M.read_only
 	end
 
 	-- Setup actions for different fzf sections

--- a/lua/aider/fzf.lua
+++ b/lua/aider/fzf.lua
@@ -43,6 +43,7 @@ function M.setup(config)
 	-- Helper to add action to fzf section
 	local function add_action_to_section(section)
 		if config.fzf_action_key then
+			vim.notify("Deprecated: fzf_action_key is deprecated. Use fzf.add instead.", vim.log.levels.WARN)
 			config.fzf.add = config.fzf_action_key
 		end
 

--- a/lua/aider/init.lua
+++ b/lua/aider/init.lua
@@ -6,6 +6,7 @@
 ---@class FuzzyFinderMappings
 ---@field add string
 ---@field read_only string
+---@field drop string
 
 ---@class AiderConfig
 ---@field spawn_on_comment boolean
@@ -62,6 +63,8 @@ M.defaults = {
 		add = "<C-l>",
 		-- Runs `/read-only <files>` for selected entries (with multi-select supported)
 		read_only = "<c-r>",
+		-- Runs `/drop`` <files> for selected entries (with multi-select supported)
+		drop = "<c-z>",
 	},
 	-- deprecated: use fzf.add and fzf.read_only instead
 	fzf_action_key = nil,
@@ -70,6 +73,8 @@ M.defaults = {
 		add = "ctrl-l",
 		-- Runs `/read-only <files>` for selected entries (with multi-select supported)
 		read_only = "ctrl-r",
+		-- Runs `/drop`` <files> for selected entries (with multi-select supported)
+		drop = "ctrl-z",
 	},
 
 	-- filter `Telescope model_picker` model picker

--- a/lua/aider/init.lua
+++ b/lua/aider/init.lua
@@ -57,20 +57,20 @@ M.defaults = {
 
 	-- deprecated: use telescope.add and telescope.read_only instead
 	telescope_action_key = nil,
-  telescope = {
-    -- Runs `/add <files>` for selected entries (with multi-select supported)
-    add = "<C-l>",
-    -- Runs `/read-only <files>` for selected entries (with multi-select supported)
-    read_only = "<c-r>"
-  },
+	telescope = {
+		-- Runs `/add <files>` for selected entries (with multi-select supported)
+		add = "<C-l>",
+		-- Runs `/read-only <files>` for selected entries (with multi-select supported)
+		read_only = "<c-r>",
+	},
 	-- deprecated: use fzf.add and fzf.read_only instead
 	fzf_action_key = nil,
-  fzf = {
-    -- Runs `/add <files>` for selected entries (with multi-select supported)
-    add = "ctrl-l",
-    -- Runs `/read-only <files>` for selected entries (with multi-select supported)
-    read_only = "ctrl-r"
-  }
+	fzf = {
+		-- Runs `/add <files>` for selected entries (with multi-select supported)
+		add = "ctrl-l",
+		-- Runs `/read-only <files>` for selected entries (with multi-select supported)
+		read_only = "ctrl-r",
+	},
 
 	-- filter `Telescope model_picker` model picker
 	model_picker_search = { "^anthropic/", "^openai/", "^gemini/" },

--- a/lua/aider/init.lua
+++ b/lua/aider/init.lua
@@ -3,16 +3,20 @@
 ---@field size function Size function for terminal
 ---@field float_opts table<string, any>? flat config options, see toggleterm.nvim for valid options
 
+---@class FuzzyFinderMappings
+---@field add string
+---@field read_only string
+
 ---@class AiderConfig
 ---@field spawn_on_comment boolean
 ---@field editor_command string|nil Command to use for editor
----@field fzf_action_key string Key to trigger aider load in fzf
+---@field fzf_action_key string|nil Key to trigger aider load in fzf
 ---@field aider_args table Additional arguments for aider CLI
 ---@field win ToggletermConfig window options
 ---@field spawn_on_startup boolean|nil
 ---@field after_update_hook function|nil
 ---@field watch_files boolean
----@field telescope_action_key string
+---@field telescope_action_key string|nil
 ---@field auto_insert true
 ---@field dark_mode function|boolean
 ---@field model_picker_search table
@@ -27,6 +31,8 @@
 ---@field git_pager string
 ---@field use_tmux boolean
 ---@field auto_show table
+---@field telescope FuzzyFinderMappings
+---@field fzf FuzzyFinderMappings
 
 local M = {}
 
@@ -49,11 +55,22 @@ M.defaults = {
 	-- function to run when aider updates file/s, useful for triggering git diffs
 	after_update_hook = nil,
 
-	-- action key for adding files to aider from fzf-lua file pickers
-	fzf_action_key = "ctrl-l",
-
-	-- action key for adding files to aider from Telescope file pickers
-	telescope_action_key = "<C-l>",
+	-- deprecated: use telescope.add and telescope.read_only instead
+	telescope_action_key = nil,
+  telescope = {
+    -- Runs `/add <files>` for selected entries (with multi-select supported)
+    add = "<C-l>",
+    -- Runs `/read-only <files>` for selected entries (with multi-select supported)
+    read_only = "<c-r>"
+  },
+	-- deprecated: use fzf.add and fzf.read_only instead
+	fzf_action_key = nil,
+  fzf = {
+    -- Runs `/add <files>` for selected entries (with multi-select supported)
+    add = "ctrl-l",
+    -- Runs `/read-only <files>` for selected entries (with multi-select supported)
+    read_only = "ctrl-r"
+  }
 
 	-- filter `Telescope model_picker` model picker
 	model_picker_search = { "^anthropic/", "^openai/", "^gemini/" },

--- a/lua/aider/toggleterm.lua
+++ b/lua/aider/toggleterm.lua
@@ -73,10 +73,23 @@ end
 
 ---Load files into aider session
 ---@param files table|nil Files or path
-function M.load_files(files)
+function M.add(files)
 	files = files or {}
 	if #files > 0 then
 		local add_paths = "/add " .. table.concat(files, " ")
+		M.send_command(add_paths)
+	end
+	if config.auto_show.on_file_add then
+		M.open()
+	end
+end
+
+---Load files into aider session
+---@param files table|nil Files or path
+function M.read_only(files)
+	files = files or {}
+	if #files > 0 then
+		local add_paths = "/read-only " .. table.concat(files, " ")
 		M.send_command(add_paths)
 	end
 	if config.auto_show.on_file_add then

--- a/lua/aider/toggleterm.lua
+++ b/lua/aider/toggleterm.lua
@@ -76,8 +76,8 @@ end
 function M.add(files)
 	files = files or {}
 	if #files > 0 then
-		local add_paths = "/add " .. table.concat(files, " ")
-		M.send_command(add_paths)
+		local cmd = "/add " .. table.concat(files, " ")
+		M.send_command(cmd)
 	end
 	if config.auto_show.on_file_add then
 		M.open()
@@ -89,11 +89,20 @@ end
 function M.read_only(files)
 	files = files or {}
 	if #files > 0 then
-		local add_paths = "/read-only " .. table.concat(files, " ")
-		M.send_command(add_paths)
+		local cmd = "/read-only " .. table.concat(files, " ")
+		M.send_command(cmd)
 	end
 	if config.auto_show.on_file_add then
 		M.open()
+	end
+end
+
+function M.drop(files)
+	files = files or {}
+	if #files > 0 then
+		local cmd = "/drop " .. table.concat(files, " ")
+		vim.notify(cmd)
+		M.send_command(cmd)
 	end
 end
 

--- a/lua/telescope/_extensions/file_pickers.lua
+++ b/lua/telescope/_extensions/file_pickers.lua
@@ -44,6 +44,11 @@ local function aider_read_only(prompt_bufnr)
 	terminal.read_only(paths)
 end
 
+local function aider_drop(prompt_bufnr)
+	local paths = get_paths(prompt_bufnr)
+	terminal.read_only(paths)
+end
+
 return telescope.register_extension({
 	setup = function()
 		-- Add mappings only to file pickers
@@ -56,6 +61,9 @@ return telescope.register_extension({
 
 			map("i", config.telescope.read_only, aider_read_only)
 			map("n", config.telescope.read_only, aider_read_only)
+
+			map("i", config.telescope.drop, aider_drop)
+			map("n", config.telescope.drop, aider_drop)
 			return true
 		end
 

--- a/lua/telescope/_extensions/file_pickers.lua
+++ b/lua/telescope/_extensions/file_pickers.lua
@@ -51,8 +51,11 @@ end
 
 return telescope.register_extension({
 	setup = function()
-		-- Add mappings only to file pickers
 		if config.telescope_action_key then
+			vim.notify(
+				"Deprecated: telescope_action_key is deprecated. Use telescope.add instead.",
+				vim.log.levels.WARN
+			)
 			config.telescope.add = config.telescope_action_key
 		end
 		local files_attach_mappings = function(_, map)

--- a/lua/telescope/_extensions/file_pickers.lua
+++ b/lua/telescope/_extensions/file_pickers.lua
@@ -8,7 +8,7 @@ local action_state = require("telescope.actions.state")
 local terminal = require("aider.terminal")
 local config = require("aider").config
 
-local function aider_action(prompt_bufnr)
+local function get_paths(prompt_bufnr)
 	local picker = action_state.get_current_picker(prompt_bufnr)
 	local paths = {}
 
@@ -30,17 +30,32 @@ local function aider_action(prompt_bufnr)
 			end
 		end
 	end
-
 	actions.close(prompt_bufnr)
+	return paths
+end
+
+local function aider_add(prompt_bufnr)
+	local paths = get_paths(prompt_bufnr)
 	terminal.add(paths)
+end
+
+local function aider_read_only(prompt_bufnr)
+	local paths = get_paths(prompt_bufnr)
+	terminal.read_only(paths)
 end
 
 return telescope.register_extension({
 	setup = function()
 		-- Add mappings only to file pickers
+		if config.telescope_action_key then
+			config.telescope.add = config.telescope_action_key
+		end
 		local files_attach_mappings = function(_, map)
-			map("i", config.telescope_action_key, aider_action)
-			map("n", config.telescope_action_key, aider_action)
+			map("i", config.telescope.add, aider_add)
+			map("n", config.telescope.add, aider_add)
+
+			map("i", config.telescope.read_only, aider_read_only)
+			map("n", config.telescope.read_only, aider_read_only)
 			return true
 		end
 

--- a/lua/telescope/_extensions/file_pickers.lua
+++ b/lua/telescope/_extensions/file_pickers.lua
@@ -32,7 +32,7 @@ local function aider_action(prompt_bufnr)
 	end
 
 	actions.close(prompt_bufnr)
-	terminal.load_files(paths)
+	terminal.add(paths)
 end
 
 return telescope.register_extension({


### PR DESCRIPTION
Fixes #5 and #7
- Deprecates the `AiderLoad` command in-favor of `AiderAdd` to better match Aider's corresponding commands
- Adds `AiderReadOnly` which behaves the same as `AiderAdd` only for `/read-only`
- Add `AiderDrop` command to execute `/drop` commands
- Adds new fzf-lua and telescope mappings for `/read-only` files and `/drop`ing files
- Adds nested object for telescope and fzf-lua pickers to add support for new custom actions, deprecating the prior flat key