### PR TITLE
Treesitter fallback comment processor

### DIFF
--- a/lua/aider/commands.lua
+++ b/lua/aider/commands.lua
@@ -11,6 +11,21 @@ local function handle_ai_comments()
     group = "ReadCommentsTSTree",
     pattern = "*",
     callback = function()
+      if terminal.is_running() then
+        if terminal.is_open() then
+          return
+        end
+        local autoshow_any = false
+        for _, value in ipairs(config.auto_show) do
+          if value == true then
+            autoshow_any = true
+          end
+        end
+        if not autoshow_any then
+          return
+        end
+      end
+
       local bufnr = vim.fn.bufnr("%")
       local matches = comments.buf_comment_matches(bufnr)
 

--- a/lua/aider/comments.lua
+++ b/lua/aider/comments.lua
@@ -62,7 +62,7 @@ function M.get_comments_regex(bufnr)
 end
 
 --- Get code comment text from a buffer
----@param bufnr
+---@param bufnr integer
 ---@return nil|string[]
 function M.get_comments(bufnr)
   local success, parser = pcall(vim.treesitter.get_parser, bufnr)

--- a/lua/aider/comments.lua
+++ b/lua/aider/comments.lua
@@ -72,7 +72,6 @@ function M.get_comments(bufnr)
   local tree = parser:parse()[1]
   local filetype = vim.bo[bufnr].filetype
   if not tree or not filetype then
-    vim.notify("getting regex comments " .. bufnr, vim.log.levels.DEBUG)
     return M.get_comments_regex(bufnr)
   end
   local query_string = [[
@@ -80,7 +79,6 @@ function M.get_comments(bufnr)
 ]]
   local ok, query = pcall(vim.treesitter.query.parse, filetype, query_string)
   if not ok then
-    vim.notify("getting regex comments b " .. bufnr, vim.log.levels.DEBUG)
     return M.get_comments_regex(bufnr)
   end
   local comments = {}

--- a/lua/aider/init.lua
+++ b/lua/aider/init.lua
@@ -153,23 +153,7 @@ M.defaults = {
   git_pager = "cat",
 
   -- function to run (e.x. for term mappings) when terminal is opened
-  on_term_open = function()
-    local function tmap(key, val)
-      local opt = { buffer = 0 }
-      vim.keymap.set("t", key, val, opt)
-    end
-    -- exit insert mode
-    tmap("<Esc>", "<C-\\><C-n>")
-    tmap("jj", "<C-\\><C-n>")
-    -- enter command mode
-    tmap(":", "<C-\\><C-n>:")
-    -- scrolling up/down
-    tmap("<C-u>", "<C-\\><C-n><C-u>")
-    tmap("<C-d>", "<C-\\><C-n><C-d>")
-    vim.opt.number = false
-    vim.opt.wrap = true
-    vim.opt.showbreak = ""
-  end,
+  on_term_open = nil,
 
   test_command = nil,
 

--- a/lua/aider/toggleterm.lua
+++ b/lua/aider/toggleterm.lua
@@ -52,6 +52,7 @@ function M.terminal()
     direction = config.win.direction,
     size = config.win.size,
     float_opts = config.win.float_opts,
+    auto_scroll = false,
     ---@param term Terminal
     on_open = function(term)
       vim.api.nvim_buf_call(term.bufnr, function()

--- a/lua/aider/toggleterm.lua
+++ b/lua/aider/toggleterm.lua
@@ -52,8 +52,15 @@ function M.terminal()
     direction = config.win.direction,
     size = config.win.size,
     float_opts = config.win.float_opts,
+    ---@param term Terminal
     on_open = function(term)
-      term:scroll_bottom()
+      vim.api.nvim_buf_call(term.bufnr, function()
+        vim.opt.number = false
+        vim.opt.wrap = true
+        vim.opt.showbreak = ""
+        vim.opt.list = false
+        term:scroll_bottom()
+      end)
     end,
     on_exit = function()
       M.__term[cwd] = nil


### PR DESCRIPTION
When treesitter isn't available, fallback to looking for AI comments using regex searches, similar to how Aider itself looks for comments